### PR TITLE
Use a halt instead of a kernel panic on Mac

### DIFF
--- a/usbkill.py
+++ b/usbkill.py
@@ -49,8 +49,8 @@ def kill_computer():
 	
 	# Poweroff computer immediately
 	if CURRENT_PLATFORM.startswith("DARWIN"):
-		# OS X (Darwin) - Will halt ungracefully, without notifying apps
-		os.system("halt -q")
+		# OS X (Darwin) - Will halt ungracefully, without signaling apps
+		os.system("killall loginwindow Finder && halt -q")
 	elif CURRENT_PLATFORM.endswith("BSD"):
 		# BSD-based systems - Will shutdown
 		os.system("shutdown -h now")

--- a/usbkill.py
+++ b/usbkill.py
@@ -49,9 +49,8 @@ def kill_computer():
 	
 	# Poweroff computer immediately
 	if CURRENT_PLATFORM.startswith("DARWIN"):
-		# OS X (Darwin) - Will reboot
-		# Use Kernel Panic instead of shutdown command (30% faster and encryption keys are released)
-		os.system("dtrace -w -n \"BEGIN{ panic();}\"")
+		# OS X (Darwin) - Will halt ungracefully, without notifying apps
+		os.system("halt -q")
 	elif CURRENT_PLATFORM.endswith("BSD"):
 		# BSD-based systems - Will shutdown
 		os.system("shutdown -h now")


### PR DESCRIPTION
halt -n is the Mac equivalent of the Linux poweroff -f, however halt -q takes a moment to flush the file system cache and still provides sudden, ungraceful halting.