### PR TITLE
Add root user status check.

### DIFF
--- a/usbkill.py
+++ b/usbkill.py
@@ -140,6 +140,10 @@ def exit_handler(signum, frame):
 	sys.exit(0)
 
 if __name__=="__main__":
+	# Check for root user status
+	if not os.geteuid()==0:
+		sys.exit("\nYou must be root to run this script.\n")
+	
 	# Check arguments
 	args = sys.argv[1:]
 	if '-h' in args or '--help' in args:


### PR DESCRIPTION
The help description states the user must be root, but if they don't ever invoke it via -h or --help, they'll never see that statement. Adding code to __main__ to check for root user status and if not, exit explaining why.