### PR TITLE
fix circular import

### DIFF
--- a/usbkill/__init__.py
+++ b/usbkill/__init__.py
@@ -1,1 +1,1 @@
-from usbkill import go
+from .usbkill import go


### PR DESCRIPTION
This fixing the following issue:

Traceback (most recent call last):
  File "/usr/bin/usbkill", line 36, in <module>
    import usbkill
  File "/usr/lib/python3.5/site-packages/usbkill/__init__.py", line 1, in <module>
    from usbkill import go
ImportError: cannot import name 'go'
