### PR TITLE
Added --osx-daemon installation option and associated plist file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 « usbkill » is an anti-forensic kill-switch that waits for a change on your USB ports and then immediately shuts down your computer.
 
+To install:
+```shell
+sudo python setup.py install
+```
+
+To install as a daemon on OSX:
+```shell
+sudo python setup.py install --osx-daemon
+```
+
+If installing as a daemon on OSX, if you wish to use a usb device, first run:
+```shell
+sudo launchctl stop USBKill
+```
+and restart the daemon when you have removed the device:
+```shell
+sudo launchctl start USBKill
+```
+please read the usbkill.ini (/etc/usbkill.ini after installation) for instructions on whitelisting usb devices!
+
+
 To run:
 
 ```shell

--- a/install/local.usbkill.plist
+++ b/install/local.usbkill.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+      <key>Label</key>
+      <string>USBKill</string>
+
+      <key>ProgramArguments</key>
+      <array>
+            <string>/usr/local/bin/usbkill</string>
+      </array>
+
+      <key>RunAtLoad</key>
+      <true/>
+</dict>
+</plist>

--- a/setup.py
+++ b/setup.py
@@ -27,13 +27,20 @@
 
 from distutils.core import setup
 from os import path
+import sys
+import shutil
 
 DIRNAME = path.dirname(path.realpath(__file__))
 
 name = lambda x : path.join(DIRNAME, x)
 
+if "--osx-daemon" in sys.argv:
+		shutil.copy2('install/local.usbkill.plist', '/Library/LaunchDaemons/local.usbkill.plist'),
+		print "Installing as OSX daemon...""
+		sys.argv.remove("--osx-daemon")
+
 setup(name='usbkill',
-      version='1.0-rc.4',
+			version='1.0-rc.4',
       description='usbkill is an anti-forensic kill-switch that waits for a change on your USB ports and then immediately shuts down your computer.',
       author='Hephaestos',
       author_email='hephaestos@riseup.net',


### PR DESCRIPTION
Added an option in setup.py to install on OSX as a daemon:
```shell
sudo python setup.py install --osx-daemon
```
will copy the added file install/local.usbkill.plist to /Library/LaunchDaemons, starting usbkill on boot.

Also added some documentation in README.md with details on:

- stopping usbkill daemon to plug or unplug a usb device
- starting usbkill daemon after plugging or unplugging a usb device
- pointing user to read /etc/usbkill.ini for whitelisting instructions

